### PR TITLE
fix: allow passing single tag in "tags" param

### DIFF
--- a/src/shared/topcoder/challenges.service.ts
+++ b/src/shared/topcoder/challenges.service.ts
@@ -22,7 +22,7 @@ export class TopcoderChallengesService {
     Object.entries(queryParams).forEach(([key, value]) => {
       if (value !== undefined && value !== null) {
         if (Array.isArray(value)) {
-          value.forEach((v) => url.searchParams.append(key, v));
+          value.forEach((v) => url.searchParams.append(`${key}[]`, v));
         } else {
           url.searchParams.append(key, value.toString());
         }


### PR DESCRIPTION
## Issue

1. Connect to Topcoder's MCP using https://github.com/modelcontextprotocol/inspector
2. Add "HTML" tag into "tags":

    <img width="1116" height="410" alt="image" src="https://github.com/user-attachments/assets/ecfca28b-705a-41c3-bc32-9dfc3bff6799" />
    
3. Running request returns `"Error fetching challenges: Request failed with status code 400"`

## Fix

Ensure that `tags` argument always treated by Challenges API as an array by adding `[]` to the `tags` param when calling Challenges API:

- instead of `tags=AI` pass `tags[]=AI`.

## Test

I've tested it locally, now it works for both cases for single tag:

<img width="2586" height="598" alt="image" src="https://github.com/user-attachments/assets/3eac7011-2f93-46a5-b3ff-3281909b66e7" />

and when passing multiple tags it still working:

<img width="2814" height="932" alt="image" src="https://github.com/user-attachments/assets/1d76c950-4fd7-495d-9cad-29d2dda847c4" />

